### PR TITLE
Use TabEnter instead of TabNew

### DIFF
--- a/plugin/buffet.vim
+++ b/plugin/buffet.vim
@@ -8,7 +8,7 @@ let g:buffet_always_show_tabline = get(g:, "buffet_always_show_tabline", 1)
 
 augroup buffet_show_tabline
     autocmd!
-    autocmd VimEnter,BufAdd,TabNew * set showtabline=2
+    autocmd VimEnter,BufAdd,TabEnter * set showtabline=2
 augroup END
 
 if has("gui")


### PR DESCRIPTION
`TabNew` was introduced in Vim version 8. We use `TabEnter` to support users of version 7.

Solves issue #31 