### PR TITLE
Add ModBuffer to separator config

### DIFF
--- a/plugin/buffet.vim
+++ b/plugin/buffet.vim
@@ -72,6 +72,7 @@ let g:buffet_has_separator = {
             \         "Buffer": g:buffet_separator,
             \         "CurrentBuffer": g:buffet_separator,
             \         "ActiveBuffer": g:buffet_separator,
+            \         "ModBuffer": g:buffet_separator,
             \     },
             \     "RightTrunc": {
             \         "Tab": g:buffet_separator,


### PR DESCRIPTION
When the tabline is at the state where a `ModBuffer` is next to the `LeftTrunc` element like so: 
`# | < 1 | apple.txt+ | banana.txt | cat.txt |`. We get an error:

```
Key not present in dictionary: ModBuffer
```

Turns out that `ModBuffer` was missing from `g:buffet_has_separator`.