### PR TITLE
Added Feature Bubble Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ Vimrc file, using `let <optiona-name> = <option-value>`:
   let g:buffet_show_index = 0
   ```
 
+* `g:buffet_bubble_index` - If set to `1`, shows bubbled numbers index before each buffer name
+* (➊ ➋ ➌ ➍ ➎ instead of 1 2 3 4 5). Requires `g:buffet_show_index` to be set to `1`.
+
+  Default:
+  ```viml
+  let g:buffet_bubble_index = 0
+  ```
+
 * `g:buffet_max_plug` - the maximum number of `<Plug>BuffetSwitch` provided. Mapping
   will be disabled if the option is set to `0`.
 

--- a/autoload/buffet.vim
+++ b/autoload/buffet.vim
@@ -272,6 +272,7 @@ function! s:Render()
     let buffer_padding = 1 + (g:buffet_use_devicons ? 1+1 : 0) + 1 + sep_len
 
     let elements = s:GetAllElements(capacity, buffer_padding)
+    let index_number= ['➊','➋','➌','➍','➎','➏','➐','➑','➒','➓','⓫','⓬','⓭','⓮','⓯','⓰','⓱','⓲','⓳','⓴','㉑', '㉒', '㉓' ,'㉔', '㉕','㉖','㉗','㉘','㉙','㉚','㉛','㉜','㉝','㉞','㉟','㊱','㊲','㊳','㊴','㊵','㊶','㊷','㊸','㊹','㊺','㊻','㊼','㊽','㊾','㊿']
 
     let render = ""
     for i in range(0, len(elements) - 2)
@@ -289,7 +290,11 @@ function! s:Render()
         let render = render . highlight
 
         if g:buffet_show_index && s:IsBufferElement(elem)
-            let render = render . " " . elem.index
+            if g:buffet_bubble_index
+                let render = render . " " . index_number[elem.index-1]
+            else
+                let render = render . " " . elem.index
+            endif
         endif
 
         let icon = ""

--- a/plugin/buffet.vim
+++ b/plugin/buffet.vim
@@ -109,7 +109,7 @@ endfor
 function! s:GetHiAttr(name, attr)
     let vim_mode = "cterm"
     let attr_suffix = ""
-    if has("gui") || has('termguicolors')
+    if has("gui") || has("termguicolors")
         let vim_mode = "gui"
         let attr_suffix = "#"
     endif

--- a/plugin/buffet.vim
+++ b/plugin/buffet.vim
@@ -29,6 +29,8 @@ endif
 
 let g:buffet_show_index = get(g:, "buffet_show_index", 0)
 
+let g:buffet_bubble_index = get(g:, "buffet_bubble_index", 0)
+
 let g:buffet_max_plug = get(g:, "buffet_max_plug", 10)
 
 if get(g:, "buffet_use_devicons", 1)


### PR DESCRIPTION
I saw another version of vim-buffet with this feature so I thought I should send a pull request.

Adds variable  `g:buffet_bubble_index`

  Default:

```viml
let g:buffet_bubble_index = 0
```

When set to 1 buffers are displayed as
➊ Buffer Name ➋ Buffer Name ➌ Buffer Name ➍  

instead of 

1 Buffer Name 2 Buffer Name 3 Buffer Name 4 Buffer Name 

This will work up to 50, which I doubt anyone will get to.

