### PR TITLE
Add missing buffer types in g:buffet_has_separator

### DIFF
--- a/plugin/buffet.vim
+++ b/plugin/buffet.vim
@@ -77,6 +77,8 @@ let g:buffet_has_separator = {
             \         "CurrentBuffer": g:buffet_separator,
             \         "ActiveBuffer": g:buffet_separator,
             \         "ModBuffer": g:buffet_separator,
+            \         "ModActiveBuffer": g:buffet_separator,
+            \         "ModCurrentBuffer": g:buffet_separator,
             \     },
             \     "RightTrunc": {
             \         "Tab": g:buffet_separator,


### PR DESCRIPTION
Some of the buffer types were left out from the `LeftTrunc` dictionary.
When decreasing the window width, we may try to get the separator for
something like LeftTrunc and ModCurrentBuffer.

To fix the crash, I added the missing buffer types into the `LeftTrunc`
dictionary under `g:buffer_has_separator`.

Fixes #56.