### PR TITLE
Fix tabline still show when there is only one buffer in some special scenarios

### DIFF
--- a/autoload/buffet.vim
+++ b/autoload/buffet.vim
@@ -119,8 +119,10 @@ function! buffet#update()
     endif
 
     " Hide tabline if only one buffer and tab open
-    if !g:buffet_always_show_tabline && len(s:buffer_ids) == 1 && tabpagenr("$") == 1
-        set showtabline=0
+    if g:buffet_always_show_tabline
+        set showtabline=2
+    else
+        set showtabline=1
     endif
 endfunction
 


### PR DESCRIPTION
When I just do vim command, there is only one buffer, but the tabline is still show as:
![](https://s3.bmp.ovh/imgs/2021/09/4b46e79e3ec133b7.png)
And I just modify the `g:showtabline` variable to a more appropriate value obey the rule:
```
'showtabline' 'stal'    number  (default 1)
                        global
        The value of this option specifies when the line with tab page labels
        will be displayed:
                0: never
                1: only if there are at least two tab pages
                2: always
        This is both for the GUI and non-GUI implementation of the tab pages
        line.
        See tab-page for more information about tab pages.
```
Then I do vim command again, the tabline disapper as:
![](https://s3.bmp.ovh/imgs/2021/09/3159730a19f2b025.png)