### PR TITLE
Add ability to use `nerdfont.vim` plugin to display devicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ tabline works and looks like.
 | `g:buffet_separator` | `''` | The character to be used for separating items in the tabline |
 | `g:buffet_show_index` | `0` | Set to `1`, show index before each buffer name. Index is useful for switching between buffers quickly |
 | `g:buffet_max_plug` | `10` | The maximum number of `<Plug>BuffetSwitch` provided. Mapping will be disabled if the option is set to `0` |
-| `g:buffet_use_devicons` | `1` | If set to `1` and [`vim-devicons`](https://github.com/ryanoasis/vim-devicons) plugin is installed, show file type icons for each buffer in the tabline. If the `vim-devicons` plugin is not present, the option will automatically default to `0` (*Note: you need to have `vim-devicons` loaded before `vim-buffet` in order to make this work*) |
+| `g:buffet_use_devicons` | `1` | If set to `1` and either [`vim-devicons`](https://github.com/ryanoasis/vim-devicons) or [`nerdfont.vim`](https://github.com/lambdalisue/nerdfont.vim) plugin is installed, show file type icons for each buffer in the tabline. If neither plugin is present, the option will automatically default to `0`. |
 | `g:buffet_tab_icon` | `'#'` | The character to be used as an icon for the tab items in the tabline |
 | `g:buffet_new_buffer_name` | `'*'` | The character to be shown as the name of a new buffer |
 | `g:buffet_modified_icon` | `'+'` | The character to be shown by the name of a modified buffer |

--- a/autoload/buffet.vim
+++ b/autoload/buffet.vim
@@ -269,7 +269,11 @@ function! s:Render()
     let trunc_len = left_trunc_len + right_trunc_len
 
     let capacity = &columns - tabs_len - trunc_len - 5
-    let buffer_padding = 1 + (g:buffet_use_devicons ? 1+1 : 0) + 1 + sep_len
+
+    let devicon_func = buffet#get_devicon_func()
+    let use_devicon = !empty(devicon_func)
+
+    let buffer_padding = 1 + (use_devicon ? 1+1 : 0) + 1 + sep_len
 
     let elements = s:GetAllElements(capacity, buffer_padding)
 
@@ -293,8 +297,8 @@ function! s:Render()
         endif
 
         let icon = ""
-        if g:buffet_use_devicons && s:IsBufferElement(elem)
-            let icon = " " . WebDevIconsGetFileTypeSymbol(elem.value)
+        if use_devicon && s:IsBufferElement(elem)
+            let icon = " " . call(devicon_func, [elem.value])
         elseif elem.type == "Tab"
             let icon = " " . g:buffet_tab_icon
         endif
@@ -429,4 +433,20 @@ function! buffet#bonly(bang, buffer)
 
         call buffet#bwipe(a:bang, b)
     endfor
+endfunction
+
+function! buffet#get_devicon_func()
+    if !exists("g:buffet_devicon_func")
+        if !get(g:, "buffet_use_devicons", 1)
+            let devicon_func = ""
+        elseif exists("*WebDevIconsGetFileTypeSymbol")
+            let devicon_func = "WebDevIconsGetFileTypeSymbol"
+        elseif exists("*nerdfont#find")
+            let devicon_func = "nerdfont#find"
+        else
+            let devicon_func = ""
+        endif
+        let g:buffet_devicon_func = devicon_func
+    endif
+    return g:buffet_devicon_func
 endfunction

--- a/plugin/buffet.vim
+++ b/plugin/buffet.vim
@@ -31,16 +31,6 @@ let g:buffet_show_index = get(g:, "buffet_show_index", 0)
 
 let g:buffet_max_plug = get(g:, "buffet_max_plug", 10)
 
-if get(g:, "buffet_use_devicons", 1)
-    if !exists("*WebDevIconsGetFileTypeSymbol")
-        let g:buffet_use_devicons = 0
-    else
-        let g:buffet_use_devicons = 1
-    endif
-else
-    let g:buffet_use_devicons = 0
-endif
-
 if !exists("g:buffet_modified_icon")
     let g:buffet_modified_icon = "+"
 endif


### PR DESCRIPTION
Hello! First, thanks for developing this useful plugin.

I am already using the [`nerdfont.vim`](https://github.com/lambdalisue/nerdfont.vim) plugin to display dev icons in the [`fern.vim`](https://github.com/lambdalisue/fern.vim) file browser. I thought it was a bit redundant to install `vim-devicons` also, so I changed `vim-buffet` to use either plugin.

The change in this PR should be completely transparent to users of this plugin. The `g:buffet_use_devicons` setting should continue to function exactly how it currently does, and if you're using `vim-devicons`, this plugin will still continue to pick that up by default.

Oh also note that a consequence of this change is that the `vim-devicons` plugin no longer needs to be registered before `vim-buffet`, since the function for generating devicons is lazily-loaded. So I updated that in the README too.

Thanks!